### PR TITLE
Add opacity transition to loading components

### DIFF
--- a/cinesplain.client/src/ui/components/common/Loading.tsx
+++ b/cinesplain.client/src/ui/components/common/Loading.tsx
@@ -4,15 +4,17 @@ import CsLogoText from "@assets/cinesplain_text_logo.svg?react";
 import { Stack, styled, useTheme } from "@mui/material";
 import { useEffect, useState } from "react";
 
-const StyledStack = styled(Stack)`
+const StyledStack = styled(Stack)<{ $transition?: boolean }>`
     position: absolute;
     left: 50%;
     top: 50%;
     transform: translate(-50%, -50%);
     overflow: hidden;
+    opacity: ${({ $transition }) => ($transition ? 1 : 0)};
+    transition: opacity 100ms ease;
 `;
 
-const WobblingStack = styled(Stack)`
+const WobblingStack = styled(Stack)<{ $transition?: boolean }>`
     width: clamp(200px, 50%, 500px);
     max-height: 80%;
     align-items: center;
@@ -38,7 +40,7 @@ const Loading = () => {
     const [degrees, setDegrees] = useState(0);
     const [initialState, setInitialState] = useState(true);
     const [splainingState, setSplainingState] = useState(false);
-    const theme = useTheme();
+    const { palette } = useTheme();
 
     useEffect(() => {
         setTimeout(() => {
@@ -61,22 +63,20 @@ const Loading = () => {
         };
     }, []);
 
-    const getLoadingStyle = () => {
-        return {
-            minHeight: "100vh",
-            alignItems: "center",
-            background: `linear-gradient(${degrees}deg,
-                  ${theme.palette.secondary.main}80,
-                  ${theme.palette.secondary.main}55,
-                  ${theme.palette.secondary.main}45,
-                  ${theme.palette.secondary.main}55,
-                  ${theme.palette.secondary.main}80),
-                  ${theme.palette.background.default}`
-        };
+    const loadingStyle = {
+        minHeight: "100vh",
+        alignItems: "center",
+        background: `linear-gradient(${degrees}deg,
+                  ${palette.secondary.main}80,
+                  ${palette.secondary.main}55,
+                  ${palette.secondary.main}45,
+                  ${palette.secondary.main}55,
+                  ${palette.secondary.main}80),
+                  ${palette.background.default}`
     };
 
     return (
-        <StyledStack className="full center" style={getLoadingStyle()}>
+        <StyledStack className="full center" sx={loadingStyle}>
             <WobblingStack>{splainingState || initialState ? <UpIcon /> : <DownIcon />}</WobblingStack>
             <StyledLogo />
         </StyledStack>


### PR DESCRIPTION
Introduce an opacity transition effect to enhance the visual appearance of loading components and add delay to appearance

closes #2