### PR TITLE
Update GitHub link in SourceCodeDisplay component

### DIFF
--- a/cinesplain.client/src/ui/components/footer/SourceCodeDisplay.tsx
+++ b/cinesplain.client/src/ui/components/footer/SourceCodeDisplay.tsx
@@ -7,13 +7,12 @@ const StyledStack = styled(Stack)`
     margin: 0.5em 1em;
 `;
 
-const SourceCodeDisplay: React.FC = () => (
+const SourceCodeDisplay = () => (
     <StyledStack>
         <Typography variant="overline" style={{ userSelect: "none" }}>
             Source Code
         </Typography>
-        <GithubLink link="https://github.com/camerongineer/cinesplain-react" title="cinesplain-react" />
-        <GithubLink link="https://github.com/camerongineer/cinesplain-api-dotnet" title="cinesplain-api-dotnet" />
+        <GithubLink link="https://github.com/camerongineer/cinesplain" title="cinesplain" />
     </StyledStack>
 );
 


### PR DESCRIPTION
The SourceCodeDisplay component now points to the correct GitHub repository. fixes #5